### PR TITLE
air 追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .history
+backend/tmp

--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,16 @@
 
 # Build Go backend
 build: ## Build the Go backend
-	@docker build -t backend ./backend
+	@docker compose build backend
 	@echo "$(GREEN)✅ Backend built successfully!$(RESET)"
 
 # Start the application with Docker Compose
 up: ## Start the application
-	@docker compose -f compose.yaml up -d
+	@docker compose up -d
 
 # Stop the application
 down: ## Stop the application
-	@docker compose -f compose.yaml down -v
+	@docker compose down -v
 
 # Format Go code
 fmt: ## Format all Go code files

--- a/backend/.air.toml
+++ b/backend/.air.toml
@@ -1,0 +1,53 @@
+# Config file for [Air](https://github.com/cosmtrek/air) in TOML format
+
+# Working directory
+# . or absolute path, please note that the directories following must be under root.
+root = "."
+tmp_dir = "tmp"
+
+[build]
+# Just plain old shell command. You could use `make` as well.
+cmd = "go build -o ./tmp/main ."
+# Binary file yields from `cmd`.
+bin = "tmp/main"
+# Customize binary, can setup environment variables when run your app.
+full_bin = "APP_ENV=dev APP_USER=air ./tmp/main"
+# Watch these filename extensions.
+include_ext = ["go", "tpl", "tmpl", "html"]
+# Ignore these filename extensions or directories.
+exclude_dir = ["assets", "tmp", "vendor", "frontend/node_modules"]
+# Watch these directories if you specified.
+include_dir = []
+# Exclude files.
+exclude_file = []
+# Exclude specific regular expressions.
+exclude_regex = ["_test.go"]
+# Exclude unchanged files.
+exclude_unchanged = true
+# Follow symlink for directories
+follow_symlink = true
+# This log file places in your tmp_dir.
+log = "air.log"
+# It's not necessary to trigger build each time file changes if it's too frequent.
+delay = 1000 # ms
+# Stop running old binary when build errors occur.
+stop_on_error = true
+# Send Interrupt signal before killing process (windows does not support this feature)
+send_interrupt = false
+# Delay after sending Interrupt signal
+kill_delay = 500 # ms
+
+[log]
+# Show log time
+time = false
+
+[color]
+# Customize each part's color. If no color found, use the raw app log.
+main = "magenta"
+watcher = "cyan"
+build = "yellow"
+runner = "green"
+
+[misc]
+# Delete tmp directory on exit
+clean_on_exit = true

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,19 +1,20 @@
 # Goイメージの選定
-FROM golang:1.21-alpine
+FROM golang:1.23-alpine
 
 # 作業ディレクトリの設定
 WORKDIR /app
 
 # Goモジュールのキャッシュ用
-COPY go.mod ./
+COPY ./backend/go.mod ./
 RUN go mod download
 
 # アプリのコピー
-COPY . .
+COPY backend .
 
 # ポートの公開
 EXPOSE 8080
 
-# ビルドと起動
-RUN go build -o app .
-CMD ["./app"]
+RUN go install github.com/air-verse/air@latest
+ENV PATH=$PATH:/root/go/bin
+
+CMD ["air", "-c", ".air.toml"]

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,3 +1,3 @@
 module deleteBlur
 
-go 1.21.3
+go 1.23.8

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,3 +1,3 @@
 module deleteBlur
 
-go 1.21.1
+go 1.21.3

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,11 +2,12 @@ services:
   backend:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: ./backend/Dockerfile
     container_name: go-backend
     ports:
       - "8080:8080"
-    working_dir: /app
+    volumes:
+      - ./backend:/app
 
   swagger-ui:
     image: swaggerapi/swagger-ui


### PR DESCRIPTION
airの最新バージョンgo1.23以上必要だったからあげた

疎通確認
```
ebarayuuga % curl http://localhost:8080
Backend prototype is running!25-04-23 18:13:16(MacBook-Air-6.local): ~/Documents/deleteBlur (main *%=)
```

ホットリロード確認
```
ebarayuuga % dc logs -f --tail 300 backend
go-backend  | Listening on :8080
go-backend exited with code 2
go-backend has been recreated
go-backend  |
go-backend  |   __    _   ___
go-backend  |  / /\  | | | |_)
go-backend  | /_/--\ |_| |_| \_ v1.61.7, built with Go go1.23.8
go-backend  |
go-backend  | mkdir /app/tmp
go-backend  | watching .
go-backend  | !exclude tmp
go-backend  | building...
go-backend  | running...
go-backend  | Listening on :8080
go-backend  | main.go has changed
go-backend  | building...
go-backend  | running...
go-backend  | Listening on :8080
go-backend  |
go-backend  | skipping main.go because contents unchanged
go-backend  | skipping main.go because contents unchanged
go-backend  | main.go has changed
go-backend  | building...
go-backend  | running...
go-backend  | Listening on :8080
go-backend  | skipping main.go because contents unchanged
```